### PR TITLE
Add `AsyncInitMixin` class

### DIFF
--- a/tests/test_async_mixin.py
+++ b/tests/test_async_mixin.py
@@ -34,7 +34,7 @@ class MockObject(xsync.AsyncInitMixin):
         self.sync = True
         self.unique = value
 
-    async def __async_init__(self, value):
+    async def __ainit__(self, value):
         self.sync = False
         self.individual = value
 
@@ -61,4 +61,4 @@ async def test_async_init():
 
 async def test_async_init_none_available():
     n = await NoAsyncInit()
-    assert hasattr(n.__class__, "__async_init__")
+    assert hasattr(n.__class__, "__ainit__")

--- a/tests/test_async_mixin.py
+++ b/tests/test_async_mixin.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2022-present, Ethan Henderson
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import xsync
+
+
+class MockObject(xsync.AsyncInitMixin):
+    def __init__(self, value):
+        self.sync = True
+        self.unique = value
+
+    async def __async_init__(self, value):
+        self.sync = False
+        self.individual = value
+
+
+class NoAsyncInit(xsync.AsyncInitMixin):
+    def __init__(self, value):
+        self.sync = True
+        self.unique = value
+
+
+def test_sync_init():
+    m = MockObject(69)
+    assert m.sync
+    assert m.unique == 69
+    assert not hasattr(m, "individual")
+
+
+async def test_async_init():
+    m = await MockObject(420)
+    assert not m.sync
+    assert m.individual == 420
+    assert not hasattr(m, "unique")
+
+
+async def test_async_init_none_available():
+    n = await NoAsyncInit()
+    assert hasattr(n.__class__, "__async_init__")

--- a/xsync/asyncinit.py
+++ b/xsync/asyncinit.py
@@ -55,6 +55,14 @@ class AsyncInitMixin:
             cls._kwargs = kwargs
 
         setattr(cls, "__init__", __init__)
+
+        if not hasattr(cls, "__async_init__"):
+
+            async def __async_init__(self: AsyncInitMixin) -> None:
+                ...
+
+            setattr(cls, "__async_init__", __async_init__)
+
         return obj
 
     def __await__(self) -> t.Generator[t.Any, t.Any, AsyncInitMixin]:

--- a/xsync/asyncinit.py
+++ b/xsync/asyncinit.py
@@ -36,7 +36,7 @@ _log = logging.getLogger(__name__)
 
 
 class AsyncInitMixin:
-    __async_init__: t.Callable[..., t.Any]
+    __ainit__: t.Callable[..., t.Any]
 
     def __new__(
         cls: type[AsyncInitMixin], *args: t.Any, **kwargs: t.Any
@@ -56,19 +56,19 @@ class AsyncInitMixin:
 
         setattr(cls, "__init__", __init__)
 
-        if not hasattr(cls, "__async_init__"):
+        if not hasattr(cls, "__ainit__"):
 
-            async def __async_init__(self: AsyncInitMixin) -> None:
+            async def __ainit__(self: AsyncInitMixin) -> None:
                 ...
 
-            setattr(cls, "__async_init__", __async_init__)
+            setattr(cls, "__ainit__", __ainit__)
 
         return obj
 
     def __await__(self) -> t.Generator[t.Any, t.Any, AsyncInitMixin]:
         async def main() -> AsyncInitMixin:
             _log.debug(f"Initialising {self.__class__.__name__!r} asynchronously")
-            await self.__async_init__(*self.__class__._args, *self.__class__._kwargs)
+            await self.__ainit__(*self.__class__._args, *self.__class__._kwargs)
             del self.__class__._args
             del self.__class__._kwargs
             return self

--- a/xsync/asyncinit.py
+++ b/xsync/asyncinit.py
@@ -34,9 +34,14 @@ import typing as t
 
 _log = logging.getLogger(__name__)
 
+if t.TYPE_CHECKING:
+    AsyncT_co = t.TypeVar("AsyncT_co", bound="AsyncInitMixin", covariant=True)
+
 
 class AsyncInitMixin:
     __ainit__: t.Callable[..., t.Any]
+    _args: tuple[t.Any, ...]
+    _kwargs: dict[str, t.Any]
 
     def __new__(
         cls: type[AsyncInitMixin], *args: t.Any, **kwargs: t.Any
@@ -65,7 +70,7 @@ class AsyncInitMixin:
 
         return obj
 
-    def __await__(self) -> t.Generator[t.Any, t.Any, AsyncInitMixin]:
+    def __await__(self: AsyncT_co) -> t.Generator[t.Any, t.Any, AsyncT_co]:
         async def main() -> AsyncInitMixin:
             _log.debug(f"Initialising {self.__class__.__name__!r} asynchronously")
             await self.__ainit__(*self.__class__._args, *self.__class__._kwargs)
@@ -73,4 +78,4 @@ class AsyncInitMixin:
             del self.__class__._kwargs
             return self
 
-        return main().__await__()
+        return main().__await__()  # type: ignore

--- a/xsync/asyncinit.py
+++ b/xsync/asyncinit.py
@@ -26,19 +26,43 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__all__ = ("AsyncInitMixin", "as_hybrid", "maybe_async", "set_async_impl")
+from __future__ import annotations
 
-__productname__ = "xsync"
-__version__ = "0.2.1"
-__description__ = "A set of tools to create hybrid sync/async interfaces."
-__url__ = "https://github.com/parafoxia/Xsync"
-__author__ = "Ethan Henderson"
-__author_email__ = "ethan.henderson.1998@gmail.com"
-__license__ = "BSD 3-Clause 'New' or 'Revised' License"
-__bugtracker__ = "https://github.com/parafoxia/Xsync/issues"
-__ci__ = "https://github.com/parafoxia/Xsync/actions"
-__changelog__ = "https://github.com/parafoxia/Xsync/releases"
+import inspect
+import logging
+import typing as t
 
-from .asyncinit import AsyncInitMixin
-from .deco import maybe_async
-from .hybrid import as_hybrid, set_async_impl
+_log = logging.getLogger(__name__)
+
+
+class AsyncInitMixin:
+    __async_init__: t.Callable[..., t.Any]
+
+    def __new__(
+        cls: type[AsyncInitMixin], *args: t.Any, **kwargs: t.Any
+    ) -> AsyncInitMixin:
+        obj = super(AsyncInitMixin, cls).__new__(cls)
+        orig_init = cls.__init__
+
+        def __init__(self: AsyncInitMixin, *args: t.Any, **kwargs: t.Any) -> None:
+            ctx = inspect.stack()[1].code_context
+
+            if not ctx or "await" not in ctx[0]:
+                _log.debug(f"Initialising {cls.__name__!r} normally")
+                return orig_init(obj, *args, **kwargs)
+
+            cls._args = args
+            cls._kwargs = kwargs
+
+        setattr(cls, "__init__", __init__)
+        return obj
+
+    def __await__(self) -> t.Generator[t.Any, t.Any, AsyncInitMixin]:
+        async def main() -> AsyncInitMixin:
+            _log.debug(f"Initialising {self.__class__.__name__!r} asynchronously")
+            await self.__async_init__(*self.__class__._args, *self.__class__._kwargs)
+            del self.__class__._args
+            del self.__class__._kwargs
+            return self
+
+        return main().__await__()


### PR DESCRIPTION
This PR adds the `xsync.AsyncInitMixin` class, which when inherited, enables the asynchronous initialisation of the subclass.

**Example**
```py
class MockObject(AsyncInitMixin):
    def __init__(self, ...) -> None:
        ...

    async def __async_init__(self, ...) -> None:
        ...
```

**Question**
Should `__async_init__` be renamed to `__ainit__`? Less explicit, but would save on characters.

**Problems**
Currently there is a typing issue.
```py
# `m` is of type `MockObject`, but believed to be of type `AsyncInitMixin` by Mypy
m = await MockObject()
```

I've tried doing something with Generics to sort this but unfortunately nothing works. One solution is to have the user typehint the class where necessary and set the return type as `t.Any` (which is not exactly ideal, but preferable to the current solution), or try and find some magic way to make this work.